### PR TITLE
Feature: Setting that allows user to pad selection with whitespaces when commenting

### DIFF
--- a/lib/sublime-block-comment.js
+++ b/lib/sublime-block-comment.js
@@ -15,6 +15,16 @@ const langs = [
   Lang(/^source\.php\.?/, '/*'  , '*/' ),
   Lang(/^text\.html\.?/ , '<!--', '-->'),
 ];
+const delimiter = ' ';
+
+export const config = {
+  delimit: {
+    title: 'Delimeter',
+    description: 'Pad selection with whitespace',
+    type: 'boolean',
+    default: false
+  }
+};
 
 export function activate() {
   disposables.push(atom.commands.add('atom-text-editor:not([mini])', { 'sublime-block-comment:toggle': toggle }));
@@ -30,6 +40,7 @@ function toggle() {
   if (!editor) return;
 
   const buffer = editor.getBuffer();
+  const delimit = atom.config.get('sublime-block-comment.delimit');
 
   buffer.transact(() => {
     for (const selection of editor.getSelectionsOrderedByBufferPosition().reverse()) {

--- a/lib/sublime-block-comment.js
+++ b/lib/sublime-block-comment.js
@@ -19,8 +19,8 @@ const delimiter = ' ';
 
 export const config = {
   delimit: {
-    title: 'Delimeter',
-    description: 'Pad selection with whitespace',
+    title: 'Delimit',
+    description: 'Pad selection with whitespace when commenting',
     type: 'boolean',
     default: false
   }
@@ -40,8 +40,7 @@ function toggle() {
   if (!editor) return;
 
   const buffer = editor.getBuffer();
-  const delimiterLen = atom.config.get('sublime-block-comment.delimit') ? delimiter.length : 0;
-  const delimiterToken = atom.config.get('sublime-block-comment.delimit') ? delimiter : '';
+  const delimit = atom.config.get('sublime-block-comment.delimit');
 
   buffer.transact(() => {
     for (const selection of editor.getSelectionsOrderedByBufferPosition().reverse()) {
@@ -51,7 +50,10 @@ function toggle() {
 
       let lang;
       if (!scopes.some((scope) => lang = langs::find((lang) => lang.test(scope)))) lang = langs[0];
-      const commentTokens = lang.commentTokens;
+      const commentTokens = {
+          open: lang.commentTokens.open + (delimit ? delimiter : ''),
+          close: (delimit ? delimiter : '') + lang.commentTokens.close
+      };
 
       // If we are inside a block comment or have one fully or partially selected, uncomment it.
       if (
@@ -68,8 +70,8 @@ function toggle() {
             (column = line.indexOf(commentTokens.close, column)) !== -1;
             column++
           ) {
-            if (isCommentDefinitionPunctuation([row, column])) {
-              blockCommentCloseRange = [[row, column], [row, column + commentTokens.close.length + delimiterLen]];
+            if (isCommentDefinitionPunctuation([row, (delimit ? column + delimiter.length : column)])) {
+              blockCommentCloseRange = [[row, column], [row, column + commentTokens.close.length]];
               break;
             }
           }
@@ -90,7 +92,7 @@ function toggle() {
             column--
           ) {
             if (isCommentDefinitionPunctuation([row, column])) {
-              blockCommentOpenRange = [[row, column], [row, column + commentTokens.open.length + delimiterLen]];
+              blockCommentOpenRange = [[row, column], [row, column + commentTokens.open.length]];
               break;
             }
           }
@@ -103,11 +105,11 @@ function toggle() {
       }
 
       // Else, wrap selection with block comment.
-      buffer.insert(range.end, delimiterToken + commentTokens.close);
-      buffer.insert(range.start, commentTokens.open + delimiterToken);
+      buffer.insert(range.end, commentTokens.close);
+      buffer.insert(range.start, commentTokens.open);
 
       // Unselect the opening and closing comment tokens.
-      const startRowColumnOffset = commentTokens.open.length + delimiterLen;
+      const startRowColumnOffset = commentTokens.open.length;
       selection.setBufferRange([
         [range.start.row, range.start.column + startRowColumnOffset],
         [range.end.row, range.end.column + (range.start.row === range.end.row ? startRowColumnOffset : 0)]

--- a/lib/sublime-block-comment.js
+++ b/lib/sublime-block-comment.js
@@ -40,7 +40,8 @@ function toggle() {
   if (!editor) return;
 
   const buffer = editor.getBuffer();
-  const delimit = atom.config.get('sublime-block-comment.delimit');
+  const delimiterLen = atom.config.get('sublime-block-comment.delimit') ? delimiter.length : 0;
+  const delimiterToken = atom.config.get('sublime-block-comment.delimit') ? delimiter : '';
 
   buffer.transact(() => {
     for (const selection of editor.getSelectionsOrderedByBufferPosition().reverse()) {
@@ -68,7 +69,7 @@ function toggle() {
             column++
           ) {
             if (isCommentDefinitionPunctuation([row, column])) {
-              blockCommentCloseRange = [[row, column], [row, column + commentTokens.close.length]];
+              blockCommentCloseRange = [[row, column], [row, column + commentTokens.close.length + delimiterLen]];
               break;
             }
           }
@@ -89,7 +90,7 @@ function toggle() {
             column--
           ) {
             if (isCommentDefinitionPunctuation([row, column])) {
-              blockCommentOpenRange = [[row, column], [row, column + commentTokens.open.length]];
+              blockCommentOpenRange = [[row, column], [row, column + commentTokens.open.length + delimiterLen]];
               break;
             }
           }
@@ -102,11 +103,11 @@ function toggle() {
       }
 
       // Else, wrap selection with block comment.
-      buffer.insert(range.end, commentTokens.close);
-      buffer.insert(range.start, commentTokens.open);
+      buffer.insert(range.end, delimiterToken + commentTokens.close);
+      buffer.insert(range.start, commentTokens.open + delimiterToken);
 
       // Unselect the opening and closing comment tokens.
-      const startRowColumnOffset = commentTokens.open.length;
+      const startRowColumnOffset = commentTokens.open.length + delimiterLen;
       selection.setBufferRange([
         [range.start.row, range.start.column + startRowColumnOffset],
         [range.end.row, range.end.column + (range.start.row === range.end.row ? startRowColumnOffset : 0)]


### PR DESCRIPTION
Hey, thanks for making this package. I use it every day!
### Change:

This pull request adds the "Delimit" setting to the package. This changes the behavior of the package in the following way:

**Delimit == false:** `selection` => `/*selection*/`

**Delimit == true:** `selection` => `/* selection */`
### Current limitations:
1. Isn't "backwards-compatible" with non-delimited comments. Example:
   
   **Delimit == true:** `/*selection*/` => `/*selection*/`
2. Calling the padding character a "delimiter" is probably a misnomer, but I'm unsure of what else to call the character besides "padding"
### Possible future work:
1. Allow user to provide a custom delimiter string

Looking forward to your feedback on this change. Thanks!
